### PR TITLE
Get json files to copy

### DIFF
--- a/fsharp-isolated.fsproj
+++ b/fsharp-isolated.fsproj
@@ -17,10 +17,10 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="host.json">
+    <None Include="host.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="local.settings.json">
+    <None Include="local.settings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>


### PR DESCRIPTION
This seems to make it start (on my machine).
The json files have to be items with Include attribute rather than Update, because where the csproj has already included, the fsproj won't - so they can't be 'Update'd.